### PR TITLE
Improve compatibilities with some column types

### DIFF
--- a/frontend/src/lib/components/widgets/DataFrame/columns/utils.ts
+++ b/frontend/src/lib/components/widgets/DataFrame/columns/utils.ts
@@ -294,6 +294,10 @@ export function toSafeArray(data: any): any[] {
     }
   }
 
+  if (data instanceof Uint8Array) {
+    return Array.from(data)
+  }
+
   try {
     const parsedData = JSON.parse(
       JSON.stringify(data, (_key, value) =>

--- a/frontend/src/lib/dataframes/Quiver.ts
+++ b/frontend/src/lib/dataframes/Quiver.ts
@@ -960,7 +960,9 @@ but was expecting \`${JSON.stringify(expectedIndexTypes)}\`.
   public static getTypeName(type: Type): IndexTypeName | string {
     // For `PeriodType` and `IntervalType` types are kept in `numpy_type`,
     // for the rest of the indexes in `pandas_type`.
-    return type.pandas_type === "object" ? type.numpy_type : type.pandas_type
+    const typeName =
+      type.pandas_type === "object" ? type.numpy_type : type.pandas_type
+    return typeName.toLowerCase().trim()
   }
 
   /** Takes the data and it's type and nicely formats it. */

--- a/lib/streamlit/elements/lib/column_config_utils.py
+++ b/lib/streamlit/elements/lib/column_config_utils.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional, Union
 
 import pandas as pd
 import pyarrow as pa
+from pandas.api.types import infer_dtype, is_categorical_dtype
 from typing_extensions import Final, Literal, TypeAlias
 
 from streamlit.elements.lib.column_types import ColumnConfig, ColumnType
@@ -475,11 +476,65 @@ def apply_data_specific_configs(
     """
     # Deactivate editing for columns that are not compatible with arrow
     if check_arrow_compatibility:
+        # Stlite: Fix non-string column names (not supported by fastparquet):
+        if infer_dtype(data_df.columns) != "string":
+            data_df.columns = data_df.columns.astype("string")
+
         for column_name, column_data in data_df.items():
+            # Stlite: Configure column types for some aspects
+            # that are not working out of the box with the parquet serialization.
+            if column_name not in columns_config:
+                if is_categorical_dtype(column_data.dtype):
+                    update_column_config(
+                        columns_config,
+                        column_name,
+                        {
+                            "type_config": {
+                                "type": "selectbox",
+                                "options": column_data.cat.categories.tolist(),
+                            },
+                        },
+                    )
+                if column_data.dtype == "object":
+                    inferred_type = infer_dtype(column_data, skipna=True)
+                    if inferred_type in ["string", "empty"]:
+                        update_column_config(
+                            columns_config,
+                            column_name,
+                            {"type_config": {"type": "text"}},
+                        )
+                    elif inferred_type == "boolean":
+                        update_column_config(
+                            columns_config,
+                            column_name,
+                            {"type_config": {"type": "checkbox"}},
+                        )
+                    elif inferred_type == "date":
+                        data_df[column_name] = pd.to_datetime(
+                            column_data.astype("string"), errors="coerce"
+                        )
+                        column_data = data_df[column_name]
+                        update_column_config(
+                            columns_config,
+                            column_name,
+                            {"type_config": {"type": "date"}},
+                        )
+                        continue
+                    elif inferred_type == "time":
+                        data_df[column_name] = pd.to_datetime(
+                            column_data.astype("string"), errors="coerce"
+                        )
+                        column_data = data_df[column_name]
+                        update_column_config(
+                            columns_config,
+                            column_name,
+                            {"type_config": {"type": "time"}},
+                        )
+
             if is_colum_type_arrow_incompatible(column_data):
                 update_column_config(columns_config, column_name, {"disabled": True})
                 # Convert incompatible type to string
-                data_df[column_name] = column_data.astype(str)
+                data_df[column_name] = column_data.astype("string")
 
     # Pandas adds a range index as default to all datastructures
     # but for most of the non-pandas data objects it is unnecessary


### PR DESCRIPTION
## Describe your changes

This PR improves the compatibility related to some column types when serialized to parquet (instead of arrow). This includes:
- Converts columns containing `interval`, `period`, `set`, `tuple` and datetime object types to string.
- Uses the newer `string` type for better null support.
- Converts all non-string column names to string
- Uses column config to configure certain types correctly for editing:  categorical, text, and boolean.
- Auto converts `date`, `time`, and `datetime` object columns to pandas native datetime columns to support editing. 
- Support byte arrays as list input. Parquet interprets number lists as byte arrays.
- Always lowercase the type name, parquet sometimes uses uppercase type names (e.g. Uint64) which are not detected correctly. 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
