### PR TITLE
Fix data_frame_to_bytes to catch TypeError in addition to ValueError

### DIFF
--- a/lib/streamlit/type_util.py
+++ b/lib/streamlit/type_util.py
@@ -1152,7 +1152,7 @@ def data_frame_to_bytes(df: DataFrame) -> bytes:
 
     try:
         df.to_parquet(buf, engine="fastparquet")
-    except ValueError as ex:
+    except (ValueError, TypeError) as ex:
         _LOGGER.info(
             "Serialization of dataframe to Parquet table was unsuccessful due to: %s. "
             "Applying automatic fixes for column types to make the dataframe Arrow-compatible.",


### PR DESCRIPTION
For https://github.com/whitphx/stlite/issues/978.

When the DataFrame column type is not string, `TypeError` is raised but not `ValueError.
So in that case, the auto-fixer is not called now even though the fixer code exists as below:
https://github.com/whitphx/streamlit/blob/55de5d2d79ec679f03329f099ae9abe389a9ce2e/lib/streamlit/type_util.py#L1092-L1096

This PR fixes the exception catcher to handle `TypeError` as well so that the auto-fixer is called in such a case correctly.

The `TypeError` raised in that case is like this:
```
Traceback (most recent call last):
  File "streamlit/runtime/scriptrunner/script_runner.py", line 598, in _run_script
  File "/home/pyodide/layout.columns2.py", line 18, in <module>
    col2.write(data)
  File "streamlit/runtime/metrics_util.py", line 408, in wrapped_func
  File "streamlit/elements/write.py", line 424, in write
  File "streamlit/runtime/metrics_util.py", line 408, in wrapped_func
  File "streamlit/elements/arrow.py", line 539, in dataframe
  File "streamlit/type_util.py", line 1154, in data_frame_to_bytes
  File "/lib/python3.12/site-packages/pandas/util/_decorators.py", line 333, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/pandas/core/frame.py", line 3101, in to_parquet
    return to_parquet(
           ^^^^^^^^^^^
  File "/lib/python3.12/site-packages/pandas/io/parquet.py", line 480, in to_parquet
    impl.write(
  File "/lib/python3.12/site-packages/pandas/io/parquet.py", line 349, in write
    self.api.write(
  File "/lib/python3.12/site-packages/fastparquet/writer.py", line 1304, in write
    fmd = make_metadata(data, has_nulls=has_nulls, ignore_columns=ignore,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/fastparquet/writer.py", line 896, in make_metadata
    get_column_metadata(data[column], column, object_dtype=oencoding))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.12/site-packages/fastparquet/util.py", line 445, in get_column_metadata
    raise TypeError(
TypeError: Column name must be a string. Got column 0 of type int
```