### PR TITLE
Ship streamlit.web Starlette pieces in the stlite wheel (spike)

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -84,8 +84,10 @@ dependencies = [
   # Starlette requires typing-extensions >= 4.10.
   "typing-extensions>=4.10.0,<5",
   # ASGI web-framework: required at runtime because Streamlit 1.57.0's
-  # streamlit/__init__.py imports streamlit.starlette → starlette_app.App.
-  # The package is pure-Python and works in Pyodide.
+  # streamlit/__init__.py imports streamlit.starlette → starlette_app.App,
+  # and stlite calls that Starlette app directly through ASGI from the JS
+  # worker (see packages/kernel/src/asgi-bridge.ts) instead of running a
+  # real HTTP server. The package is pure-Python and works in Pyodide.
   "starlette>=0.40.0",
   # Required by starlette (pure Python, Pyodide-compatible).
   "anyio>=4.0.0",
@@ -143,8 +145,8 @@ all = [
   "rich>=11.0.0",
 ]
 
-[project.scripts]
-streamlit = "streamlit.web.cli:main"
+# Stlite: dropped the `streamlit` console script — its entry point is
+# streamlit.web.cli, which is excluded from the wheel above.
 
 [project.urls]
 Homepage = "https://streamlit.io"
@@ -159,7 +161,15 @@ zip-safe = false
 include-package-data = true
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*", "streamlit.web", "streamlit.web.*"]
+exclude = [
+  "tests",
+  "tests.*",
+  # Stlite: streamlit.web.cli pulls in click + uvicorn (not Pyodide-compatible)
+  # and is only used to launch the Tornado/Starlette server, which the JS worker
+  # bypasses. The rest of streamlit.web (notably streamlit.web.server.starlette
+  # and streamlit.web.bootstrap) is shipped and called directly via ASGI.
+  "streamlit.web.cli",
+]
 
 # PEP 561: https://mypy.readthedocs.io/en/stable/installed_packages.html
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Summary

Streamlit-side change for the [ASGI bridge spike on whitphx/stlite#2043](https://github.com/whitphx/stlite/pull/2043). In place of stlite's hand-rolled Tornado-style server emulation, the JS worker can now call upstream's `streamlit.web.server.starlette.starlette_app.App` directly via ASGI; for that to work the stlite wheel needs to ship `streamlit.web.server.starlette.*`.

## What changes

- `lib/pyproject.toml` — narrows the wheel exclude from all of `streamlit.web` to just `streamlit.web.cli` (the latter pulls in click + uvicorn, neither needed in Pyodide). Also drops the now-dangling `streamlit = "streamlit.web.cli:main"` console script entry.

The runtime ASGI dep stack (starlette, anyio, python-multipart, itsdangerous) was already uncommented in ["deps: install Starlette runtime stack"](https://github.com/whitphx/streamlit/commit/0b1e0e2ff3) on this branch.

## Test plan

- [x] `make streamlit-wheel` and `make stlite-lib-wheel` complete locally
- [x] Spike vitest (`packages/kernel/src/asgi-bridge.test.ts` on whitphx/stlite#2043) — both tests green: `GET /_stcore/health` returns 200 "ok" and the WebSocket handshake to `/_stcore/stream` accepts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)