### PR TITLE
Support the server-backed (Cloudflare Workers) stlite runtime

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -23,6 +23,9 @@ import { getLogger } from "loglevel"
 import { flushSync } from "react-dom"
 import Hotkeys from "react-hot-keys"
 
+import { StliteKernelContext } from "@stlite/kernel/contexts"
+import { ConnectionManager as StliteConnectionManager } from "@stlite/kernel/react"
+
 import AppView from "@streamlit/app/src/components/AppView/AppView"
 import DeployButton from "@streamlit/app/src/components/DeployButton/DeployButton"
 import MainMenu from "@streamlit/app/src/components/MainMenu/MainMenu"
@@ -57,7 +60,7 @@ import {
   LibConfig,
   parseUriIntoBaseParts,
   StreamlitEndpoints,
-  ConnectionManager,
+  ConnectionManager as ServerConnectionManager,
 } from "@streamlit/connection"
 import {
   AppRoot,
@@ -259,7 +262,10 @@ export class App extends PureComponent<Props, State> {
 
   private readonly sessionEventDispatcher = new SessionEventDispatcher()
 
-  private connectionManager: ConnectionManager | null
+  private connectionManager:
+    | ServerConnectionManager
+    | StliteConnectionManager
+    | null
 
   private readonly widgetMgr: WidgetStateManager
 
@@ -292,6 +298,9 @@ export class App extends PureComponent<Props, State> {
   // we have received a NewSession message after the latest rerun request.
   // This will allow us to ignore finished messages from previous script runs.
   private hasReceivedNewSession: boolean = false
+
+  static override contextType = StliteKernelContext
+  override context!: React.ContextType<typeof StliteKernelContext>
 
   public constructor(props: Props) {
     super(props)
@@ -549,7 +558,8 @@ export class App extends PureComponent<Props, State> {
 
     this.applyInitialHostConfig()
 
-    this.connectionManager = new ConnectionManager({
+    const kernel = this.context?.kernel
+    const connectionManagerProps = {
       getLastSessionId: () => this.sessionInfo.last?.sessionId,
       endpoints: this.endpoints,
       onMessage: this.handleMessage,
@@ -626,7 +636,15 @@ export class App extends PureComponent<Props, State> {
         // Set the streamlit-lib specific config settings in LibConfigContext:
         this.setLibConfig(libConfig)
       },
-    })
+    }
+
+    this.connectionManager =
+      kernel == null
+        ? new ServerConnectionManager(connectionManagerProps)
+        : new StliteConnectionManager({
+            ...connectionManagerProps,
+            kernel,
+          })
 
     this.isInitializingConnectionManager = false
   }
@@ -641,6 +659,11 @@ export class App extends PureComponent<Props, State> {
       type: "SCRIPT_RUN_STATE_CHANGED",
       scriptRunState: this.state.scriptRunState,
     })
+
+    const kernel = this.context?.kernel
+    if (kernel != null) {
+      this.uploadClient.setKernel(kernel)
+    }
 
     if (isScrollingHidden()) {
       document.body.classList.add("embedded")

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -23,9 +23,6 @@ import { getLogger } from "loglevel"
 import { flushSync } from "react-dom"
 import Hotkeys from "react-hot-keys"
 
-import { StliteKernelContext } from "@stlite/kernel/contexts"
-import { ConnectionManager } from "@stlite/kernel/react"
-
 import AppView from "@streamlit/app/src/components/AppView/AppView"
 import DeployButton from "@streamlit/app/src/components/DeployButton/DeployButton"
 import MainMenu from "@streamlit/app/src/components/MainMenu/MainMenu"
@@ -60,6 +57,7 @@ import {
   LibConfig,
   parseUriIntoBaseParts,
   StreamlitEndpoints,
+  ConnectionManager,
 } from "@streamlit/connection"
 import {
   AppRoot,
@@ -294,9 +292,6 @@ export class App extends PureComponent<Props, State> {
   // we have received a NewSession message after the latest rerun request.
   // This will allow us to ignore finished messages from previous script runs.
   private hasReceivedNewSession: boolean = false
-
-  static override contextType = StliteKernelContext
-  override context!: React.ContextType<typeof StliteKernelContext>
 
   public constructor(props: Props) {
     super(props)
@@ -554,13 +549,7 @@ export class App extends PureComponent<Props, State> {
 
     this.applyInitialHostConfig()
 
-    const kernel = this.context?.kernel
-    if (kernel == null) {
-      throw new Error("Kernel is not set in the context.")
-    }
-
     this.connectionManager = new ConnectionManager({
-      kernel,
       getLastSessionId: () => this.sessionInfo.last?.sessionId,
       endpoints: this.endpoints,
       onMessage: this.handleMessage,
@@ -643,11 +632,6 @@ export class App extends PureComponent<Props, State> {
   }
 
   override componentDidMount(): void {
-    const kernel = this.context?.kernel
-    if (kernel == null) {
-      throw new Error("Kernel is not set in the context.")
-    }
-
     // Initialize connection manager here, to avoid
     // "Can't call setState on a component that is not yet mounted." error.
     this.initializeConnectionManager()
@@ -657,8 +641,6 @@ export class App extends PureComponent<Props, State> {
       type: "SCRIPT_RUN_STATE_CHANGED",
       scriptRunState: this.state.scriptRunState,
     })
-
-    this.uploadClient.setKernel(kernel)
 
     if (isScrollingHidden()) {
       document.body.classList.add("embedded")

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -63,10 +63,14 @@ export function isHostConfigBypassEnabled(): boolean {
  * Return the BaseUriParts for either the given url or the global window
  */
 export function parseUriIntoBaseParts(url?: string): URL {
-  // Stlite: If we're running in an iframe, the href might be "about:blank".
-  // In that case, we want to use the current path as the base path.
+  // Stlite: If we're running in an iframe, the href might be "about:blank",
+  // which is not a usable URL base (`new URL("/", "/")` throws). Substitute a
+  // placeholder origin so parsing succeeds; what matters downstream is the
+  // resulting (empty) base path, not the placeholder host.
   const fallbackUrl =
-    window.location.href === "about:blank" ? "/" : window.location.href
+    window.location.href === "about:blank"
+      ? "http://localhost/"
+      : window.location.href
   const currentUrl = new URL(url ?? fallbackUrl, fallbackUrl)
 
   currentUrl.pathname = currentUrl.pathname

--- a/frontend/connection/src/utils.ts
+++ b/frontend/connection/src/utils.ts
@@ -65,9 +65,9 @@ export function isHostConfigBypassEnabled(): boolean {
 export function parseUriIntoBaseParts(url?: string): URL {
   // Stlite: If we're running in an iframe, the href might be "about:blank".
   // In that case, we want to use the current path as the base path.
-  const currentUrl = new URL(
-    window.location.href === "about:blank" ? "" : window.location.href
-  )
+  const fallbackUrl =
+    window.location.href === "about:blank" ? "/" : window.location.href
+  const currentUrl = new URL(url ?? fallbackUrl, fallbackUrl)
 
   currentUrl.pathname = currentUrl.pathname
     .replace(FINAL_SLASH_RE, "")

--- a/frontend/lib/src/FileUploadClient.ts
+++ b/frontend/lib/src/FileUploadClient.ts
@@ -119,6 +119,18 @@ export class FileUploadClient {
   ): Promise<void> {
     this.offsetPendingRequestCount(widget.formId, 1)
 
+    if (this.kernel == null) {
+      return this.endpoints
+        .uploadFileUploaderFile(
+          fileUploadUrl,
+          file,
+          this.sessionInfo.current.sessionId,
+          onUploadProgress,
+          signal
+        )
+        .finally(() => this.offsetPendingRequestCount(widget.formId, -1))
+    }
+
     // Stlite: Use form upload
     const form = new FormData()
     form.append(file.name, file)
@@ -160,7 +172,10 @@ export class FileUploadClient {
    */
   public deleteFile(fileUrl: string): Promise<void> {
     if (this.kernel == null) {
-      throw new Error("Kernel not ready")
+      return this.endpoints.deleteFileAtURL?.(
+        fileUrl,
+        this.sessionInfo.current.sessionId
+      ) ?? Promise.resolve()
     }
 
     return this.kernel

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -139,10 +139,8 @@ function DownloadButton(props: Props): ReactElement {
       widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
     }
 
-    if (
-      element.url.startsWith("/media") &&
-      downloadFileFromStlite(element.url)
-    ) {
+    if (element.url.startsWith("/media")) {
+      void downloadFileFromStlite(element.url)
       return
     }
 

--- a/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
+++ b/frontend/lib/src/components/widgets/DownloadButton/DownloadButton.tsx
@@ -139,8 +139,10 @@ function DownloadButton(props: Props): ReactElement {
       widgetMgr.setTriggerValue(element, { fromUi: true }, fragmentId)
     }
 
-    if (element.url.startsWith("/media")) {
+    if (
+      element.url.startsWith("/media") &&
       downloadFileFromStlite(element.url)
+    ) {
       return
     }
 

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -84,8 +84,10 @@ dependencies = [
   # Starlette requires typing-extensions >= 4.10.
   "typing-extensions>=4.10.0,<5",
   # ASGI web-framework: required at runtime because Streamlit 1.57.0's
-  # streamlit/__init__.py imports streamlit.starlette → starlette_app.App.
-  # The package is pure-Python and works in Pyodide.
+  # streamlit/__init__.py imports streamlit.starlette → starlette_app.App,
+  # and stlite calls that Starlette app directly through ASGI from the JS
+  # worker (see packages/kernel/src/asgi-bridge.ts) instead of running a
+  # real HTTP server. The package is pure-Python and works in Pyodide.
   "starlette>=0.40.0",
   # Required by starlette (pure Python, Pyodide-compatible).
   "anyio>=4.0.0",
@@ -143,8 +145,8 @@ all = [
   "rich>=11.0.0",
 ]
 
-[project.scripts]
-streamlit = "streamlit.web.cli:main"
+# Stlite: dropped the `streamlit` console script — its entry point is
+# streamlit.web.cli, which is excluded from the wheel above.
 
 [project.urls]
 Homepage = "https://streamlit.io"
@@ -159,7 +161,15 @@ zip-safe = false
 include-package-data = true
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*", "streamlit.web", "streamlit.web.*"]
+exclude = [
+  "tests",
+  "tests.*",
+  # Stlite: streamlit.web.cli pulls in click + uvicorn (not Pyodide-compatible)
+  # and is only used to launch the Tornado/Starlette server, which the JS worker
+  # bypasses. The rest of streamlit.web (notably streamlit.web.server.starlette
+  # and streamlit.web.bootstrap) is shipped and called directly via ASGI.
+  "streamlit.web.cli",
+]
 
 # PEP 561: https://mypy.readthedocs.io/en/stable/installed_packages.html
 [tool.setuptools.package-data]

--- a/lib/streamlit/components/v2/manifest_scanner.py
+++ b/lib/streamlit/components/v2/manifest_scanner.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import importlib.metadata
 import importlib.util
 import os
+import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
@@ -596,9 +597,11 @@ def scan_component_manifests(
         max_workers, len(candidate_distributions), 16
     )  # Don't use more threads than packages or 16
 
-    # Pyodide-based runtimes such as Cloudflare Python Workers may expose the
-    # threading module without permitting new native threads.
-    if max_workers <= 1:
+    # Pyodide-based runtimes (sys.platform == "emscripten", e.g. Cloudflare
+    # Python Workers) expose the threading module without permitting new native
+    # threads, so scan sequentially there no matter how many candidate packages
+    # exist.
+    if max_workers <= 1 or sys.platform == "emscripten":
         _LOGGER.debug(
             "Scanning %d candidate packages for component manifests sequentially",
             len(candidate_distributions),

--- a/lib/streamlit/components/v2/manifest_scanner.py
+++ b/lib/streamlit/components/v2/manifest_scanner.py
@@ -596,6 +596,20 @@ def scan_component_manifests(
         max_workers, len(candidate_distributions), 16
     )  # Don't use more threads than packages or 16
 
+    # Pyodide-based runtimes such as Cloudflare Python Workers may expose the
+    # threading module without permitting new native threads.
+    if max_workers <= 1:
+        _LOGGER.debug(
+            "Scanning %d candidate packages for component manifests sequentially",
+            len(candidate_distributions),
+        )
+        for dist in candidate_distributions:
+            result = _process_single_package(dist)
+            if result:
+                manifests.append(result)
+        _LOGGER.debug("Found %d component manifests total", len(manifests))
+        return manifests
+
     _LOGGER.debug(
         "Scanning %d candidate packages for component manifests using %d worker threads",
         len(candidate_distributions),

--- a/lib/tests/streamlit/components/v2/test_manifest_scanner.py
+++ b/lib/tests/streamlit/components/v2/test_manifest_scanner.py
@@ -1144,3 +1144,55 @@ def test_process_single_package_mixed_install_scenarios() -> None:
         assert manifest.name == "mixed-component"
         assert manifest.version == "1.5.0"
         assert package_root == package_dir
+
+
+def test_scan_component_manifests_sequential_on_emscripten(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that Pyodide (emscripten) scans sequentially even with 2+ packages.
+
+    Pyodide-based runtimes expose the threading module without permitting new
+    native threads, so the thread pool must not be used there regardless of
+    the candidate-package count.
+    """
+    import sys
+
+    from streamlit.components.v2.manifest_scanner import scan_component_manifests
+
+    dists = []
+    for i in range(2):
+        dist = Mock()
+        dist.name = f"streamlit-package-{i}"
+        metadata = MagicMock()
+        metadata_dict = {
+            "Name": f"streamlit-package-{i}",
+            "Summary": f"Description for streamlit-package-{i}",
+        }
+        metadata.__getitem__.side_effect = metadata_dict.__getitem__
+        metadata.__contains__.side_effect = metadata_dict.__contains__
+        metadata.get_all.return_value = []
+        dist.metadata = metadata
+        dists.append(dist)
+
+    monkeypatch.setattr(sys, "platform", "emscripten")
+
+    with (
+        patch(
+            "streamlit.components.v2.manifest_scanner.importlib.metadata.distributions"
+        ) as mock_distributions,
+        patch(
+            "streamlit.components.v2.manifest_scanner._process_single_package"
+        ) as mock_process,
+        patch(
+            "streamlit.components.v2.manifest_scanner.ThreadPoolExecutor"
+        ) as mock_executor,
+    ):
+        mock_distributions.return_value = dists
+        mock_process.return_value = None
+
+        manifests = scan_component_manifests()
+
+        assert manifests == []
+        assert mock_process.call_count == 2
+        # Anti-regression: no thread pool may be created on emscripten.
+        mock_executor.assert_not_called()


### PR DESCRIPTION
Streamlit-fork changes that back the new `@stlite/cloudflare` (Cloudflare Workers) target, where Streamlit runs server-side through the Starlette ASGI app instead of fully in the browser.

Commits (oldest first):

- Ship streamlit.web Starlette pieces in the Stlite wheel (spike)
- fix(components): avoid thread pool for single manifest scan
- fix(frontend): support server-backed runtime
- fix(stlite): honor explicit backend base URL
- fix(frontend): handle stlite media downloads asynchronously
- fix(frontend): keep stlite browser runtime path

Base: `stlite-1.57.0`. 5 files changed, +54/-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
